### PR TITLE
Cross OS functionality

### DIFF
--- a/game.py
+++ b/game.py
@@ -242,9 +242,9 @@ class Game:
                 self.ten_rule()
                 i = change_player(i)
             i = change_player(i)
-            os.system('cls')
+            os.system('cls||clear')
 
-        os.system('cls')
+        os.system('cls||clear')
         self.show_table()
         print(f'#####################   {players[i].name} wins   #####################')
         sys.exit()


### PR DESCRIPTION
added '||clear' to the os.system('cls') command, so now it should function on windows, linux, and macos